### PR TITLE
feat: Webフォントを使用するように変更

### DIFF
--- a/libs.org
+++ b/libs.org
@@ -41,5 +41,5 @@ title: %s
 description: %s
 footer:  〈完全なプログラミング〉を目指す会 2020
 _footer: \"\"
----" title desc))
+style: |\n  @import url(\"https://fonts.googleapis.com/css2?family=Noto+Sans+JP&display=swap\");\n  section {\n    font-family: 'Noto Sans JP', sans-serif;\n  }\n---" title desc))
 #+end_src

--- a/src/architecture.md
+++ b/src/architecture.md
@@ -11,6 +11,11 @@ title: 第五回 アーキテクチャ
 description: 〈完全なプログラミング〉を目指す会 2020 アーキテクチャ編です
 footer: 〈完全なプログラミング〉を目指す会 2020
 _footer: ""
+style: |
+  @import url("https://fonts.googleapis.com/css2?family=Noto+Sans+JP&display=swap");
+  section {
+    font-family: 'Noto Sans JP', sans-serif;
+  }
 
 ---
 

--- a/src/document.md
+++ b/src/document.md
@@ -9,6 +9,11 @@ title: 第四回 ドキュメント
 description: 〈完全なプログラミング〉を目指す会 2020 ドキュメント編です
 footer:  〈完全なプログラミング〉を目指す会 2020
 _footer: ""
+style: |
+  @import url("https://fonts.googleapis.com/css2?family=Noto+Sans+JP&display=swap");
+  section {
+    font-family: 'Noto Sans JP', sans-serif;
+  }
 ---
 
 

--- a/src/index.md
+++ b/src/index.md
@@ -9,6 +9,11 @@ title: 〈完全なプログラミング〉を目指す会 2020
 description: 〈完全なプログラミング〉を目指す会 2020 の資料へのインデックスです
 footer:  〈完全なプログラミング〉を目指す会 2020
 _footer: ""
+style: |
+  @import url("https://fonts.googleapis.com/css2?family=Noto+Sans+JP&display=swap");
+  section {
+    font-family: 'Noto Sans JP', sans-serif;
+  }
 ---
 
 

--- a/src/intro.md
+++ b/src/intro.md
@@ -9,6 +9,11 @@ title: 第一回 〈完全なプログラミング〉
 description: 〈完全なプログラミング〉を目指す会 2020 の導入です
 footer:  〈完全なプログラミング〉を目指す会 2020
 _footer: ""
+style: |
+  @import url("https://fonts.googleapis.com/css2?family=Noto+Sans+JP&display=swap");
+  section {
+    font-family: 'Noto Sans JP', sans-serif;
+  }
 ---
 
 

--- a/src/naming.md
+++ b/src/naming.md
@@ -9,6 +9,11 @@ title: 第三回 命名
 description: 〈完全なプログラミング〉を目指す会 2020 命名編です
 footer:  〈完全なプログラミング〉を目指す会 2020
 _footer: ""
+style: |
+  @import url("https://fonts.googleapis.com/css2?family=Noto+Sans+JP&display=swap");
+  section {
+    font-family: 'Noto Sans JP', sans-serif;
+  }
 ---
 
 

--- a/src/oop.md
+++ b/src/oop.md
@@ -9,6 +9,11 @@ title: 第二回 オブジェクト指向プログラミング
 description: 〈完全なプログラミング〉を目指す会 2020 オブジェクト指向プログラミング編です
 footer:  〈完全なプログラミング〉を目指す会 2020
 _footer: ""
+style: |
+  @import url("https://fonts.googleapis.com/css2?family=Noto+Sans+JP&display=swap");
+  section {
+    font-family: 'Noto Sans JP', sans-serif;
+  }
 ---
 
 


### PR DESCRIPTION
Noto Sans JP を Webフォントとして利用することで、ビルド環境にフォントをインストールすることなく日本語表示を可能にします。