### PR TITLE
fix(ci): playwright を devDependencies から削除して GitHub Actions を修正

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -34,6 +34,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install Playwright Chromium
+        run: |
+          npx playwright install chromium
+          CHROME=$(node -e "const {chromium} = require('playwright'); console.log(chromium.executablePath())")
+          echo "CHROME_PATH=$CHROME" >> $GITHUB_ENV
+
       - name: Build Marp slide deck
         run: npm run build
         env:

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -34,12 +34,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Install Playwright Chromium
-        run: |
-          npx playwright install chromium
-          CHROME=$(node -e "const {chromium} = require('playwright'); console.log(chromium.executablePath())")
-          echo "CHROME_PATH=$CHROME" >> $GITHUB_ENV
-
       - name: Build Marp slide deck
         run: npm run build
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@mermaid-js/mermaid-cli": "^11.4.2",
         "cpx2": "^8.0.0",
         "npm-run-all": "^4.1.5",
-        "playwright": "^1.60.0",
         "rimraf": "^6.0.1"
       }
     },
@@ -5292,51 +5291,19 @@
         "node": ">= 6"
       }
     },
-    "node_modules/playwright": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.60.0"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
     "node_modules/playwright-core": {
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
       "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/points-on-curve": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@mermaid-js/mermaid-cli": "^11.4.2",
     "cpx2": "^8.0.0",
     "npm-run-all": "^4.1.5",
-    "playwright": "^1.60.0",
     "rimraf": "^6.0.1"
   }
 }


### PR DESCRIPTION
## 問題

PR #50 で `playwright` が `devDependencies` に追加されたことで、GitHub Actions のビルドが失敗するようになった。

`playwright` は `npm ci` 実行時にブラウザのダウンロードを試みる（あるいはブラウザ検出に影響する）ため、GitHub Actions 環境で marp が OG 画像（JPG）生成に使うブラウザを見つけられなくなっていた。

## 原因

[marp-cli-example では意図的に puppeteer / playwright を外している](https://github.com/yhatt/marp-cli-example/commit/697c040599f02ec0fe86466adb519fb64c172775)。このプロジェクトもその方針に追従していたが、PR #50 でビジュアル検証用として `playwright` が追加されてしまっていた。

`playwright` はビルドスクリプト・ワークフローのいずれでも実際には使用されていない。

## 修正

- `package.json` から `playwright` を削除
- `package-lock.json` を更新