### PR TITLE
fix: marp.config.mjs の const YEAR を除去し footer へ 2026 を直書きする

### DIFF
--- a/marp.config.mjs
+++ b/marp.config.mjs
@@ -1,14 +1,13 @@
 /** @type {import('@marp-team/marp-cli').Config} */
 
-// 年度の単一定義。年を変えるときはここだけ書き換える。
-const YEAR = '2026'
-
 // 全スライド横断の共通フロントマター（旧 libs.org / setupfile.org の後継）。
 // ここを書き換えると全デッキへ反映される。各 src/*.md は固有の
 // title / description のみをフロントマターに持つ。
+// 年（2026）は DRY 化しない。src/*.md にも 2026 が点在するため、年変更時は
+// リポジトリ全体を grep して手修正する（PR #65 の決定に従う）。
 const SHARED_FRONT_MATTER = `class: lead
 paginate: true
-footer: 〈完全なプログラミング〉を目指す会 ${YEAR}
+footer: 〈完全なプログラミング〉を目指す会 2026
 _paginate: false
 _footer: ""
 `


### PR DESCRIPTION
## 概要

`marp.config.mjs` の `const YEAR = '2026'` を除去し、footer に `2026` を直書きする。PR #65 の決定（DRY 化しない・年変更時は grep で手修正）と整合させる。

## 変更内容

- `YEAR` 定数の定義を削除
- footer テンプレートの `${YEAR}` をリテラル `2026` に置換
- 年は意図的に DRY 化しない旨をコメントで明記（`src/*.md` にも 2026 が点在するため、年変更時はリポジトリ全体を grep して手修正する）

## 背景

`YEAR` の参照は footer の 1 箇所のみで、年「2026」は `src/*.md` に 13 箇所点在している。定数化しても結局 src を手修正する必要があり DRY 効果はゼロで、むしろ単一の真実源があるかのような誤った印象を与えていた。PR #65 のコミット本文（4fe3dbe）は `const YEAR` を棄却する決定を記録していたが、マージ後のコードに残存しており決定記録と不整合だったため、これを解消する。

Closes #66

https://claude.ai/code/session_01KxxZMxq4MJPEHe4GGu521G