### PR TITLE
docs: 共通フロントマターの発見性を補強する

### DIFF
--- a/.claude/rules/slides.md
+++ b/.claude/rules/slides.md
@@ -12,7 +12,7 @@ paths:
 
 ## オーサリング
 
-- 全スライド横断の共通フロントマター（フッター・ページ番号など）は `marp.config.mjs` に定義済み。各 `.md` には固有の `title` と `description` のみを記述する。
+- 全スライド横断の共通フロントマター（フッター・ページ番号・`class: lead` など）は `marp.config.mjs` に定義済み。各 `.md` には固有の `title` と `description` のみを記述する。
 - フォントなど全体に影響するスタイルは `kanpro.css` で指定する。Web フォントの利用が推奨。
 - UML などの図は `src/diagrams/*.mmd`（Mermaid）で記述し、`npm run diagrams` で `src/assets/*.png` に再生成する。図を変更する際は必ずソースの `.mmd` を編集して再生成し、生成した PNG をコミットする。
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ yewton が社内向けに **〈完全なプログラミング〉を目指す会*
 
 スライドは [Marp](https://github.com/marp-team/marp) を用いて作成しており、ビルド・デプロイの構成は [yhatt/marp-cli-example](https://github.com/yhatt/marp-cli-example) を参考にしています。
 
-各スライドは `src` ディレクトリ以下の `.md` を編集します。全スライド横断の共通設定（フッターやページ番号などのフロントマター）は `marp.config.mjs` に定義してあり、各 `.md` には固有の `title` と `description` のみを記述します。
+各スライドは `src` ディレクトリ以下の `.md` を編集します。全スライド横断の共通設定（フッター・ページ番号・`class: lead` などの共通フロントマター）は `marp.config.mjs` に定義してあり、各 `.md` には固有の `title` と `description` のみを記述します。
 
 以下を実行するとプレビュー用の Marp サーバーが立ち上がります:
 

--- a/marp.config.mjs
+++ b/marp.config.mjs
@@ -16,6 +16,8 @@ _footer: ""
 // 解釈する前段（render の入力文字列）で結合するため、結果は共通設定を各 .md に
 // 直接書いていた従来と等価になる。ビルド・プレビュー(`marp -s src`)・ウォッチの
 // いずれでもこのエンジンが使われるため、編集時の体験も保たれる。
+// Marp には宣言的な共通フロントマター機構が存在せず（メンテナによる意図的な設計）、
+// engine プラグインによるこの前処理が公式の案内する唯一の回避策である。
 const injectSharedFrontMatter = (markdown) => {
   const opening = /^---\r?\n/.exec(markdown)
   if (opening) {


### PR DESCRIPTION
## 概要

`class: lead` がどこにも書いていないのに効く理由が分かりにくい問題（発見性の欠如）を、機構を変えずに補強する。

## 変更内容

- **`README.md`**: 共通設定の説明に `class: lead` を明示する（「フッターやページ番号など」→「フッター・ページ番号・`class: lead` など」）
- **`.claude/rules/slides.md`**: 同様に `class: lead` を明示する
- **`marp.config.mjs`**: `injectSharedFrontMatter` のコメントに WHY を追加する（Marp には宣言的な共通フロントマター機構が存在せず、engine プラグイン方式が公式の唯一の回避策である旨）

## 背景

Marp にはフロントマターを外部から宣言的に与える公式機構がなく（メンテナによる意図的な設計）、engine プラグインによる前処理がメンテナの案内する唯一の回避策である。この前処理は「非標準」ではなく正攻法そのものだが、コードを見るだけでは経緯が分からないため、「この前処理は非標準では?」という再検討（cf. PR #65）が蒸し返されるリスクがあった。

Closes #68

https://claude.ai/code/session_01E5kCN5D3tWinFhQTJExL1P